### PR TITLE
Define only the property "font-family" instead of "font" property with "!important"

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -1,11 +1,6 @@
-[class^="el-icon-fa"], [class*=" el-icon-fa"] {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome!important;
-  font-size: inherit;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-};
-
-@import url("../node_modules/font-awesome/less/font-awesome");
+@import url("../../../node_modules/font-awesome/less/font-awesome");
 @fa-css-prefix: el-icon-fa;
+
+[class^="el-icon-fa"], [class*=" el-icon-fa"] {
+  font-family: FontAwesome !important;
+}


### PR DESCRIPTION
Using this config allows users to use others registered class like el-icon-fa-4x.