### PR TITLE
Define only the property "font-family"

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -1,10 +1,5 @@
 [class^="el-icon-fa"], [class*=" el-icon-fa"] {
-  display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome!important;
-  font-size: inherit;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-family: FontAwesome !important;
 };
 
 @import url("../node_modules/font-awesome/less/font-awesome");


### PR DESCRIPTION
Define only the property "font-family" instead of "font" property with "!important"
Using this config allows users to use others registered class like el-icon-fa-4x.